### PR TITLE
Anterior and posterior lateral of trunk shield: all absent (0); one of present or all of present (1).

### DIFF
--- a/Character list of antiarchs to be compiled.md
+++ b/Character list of antiarchs to be compiled.md
@@ -242,6 +242,10 @@
 
 > - **very low trunk shield in *Xichonolepis* should be a derived feature. Is this a feature of sinolepids? How to define it?**
 
+51. Anterior and posterior lateral of trunk shield: all absent (0); one of present or all of present (1).
+
+> **Newly added character (Yan).**
+
 51. Number of median dorsal plates: one (0); two (1).
 
 > Young (1984, 1988), Character 1; Zhu (1996), Character 11; Pan et al. (2017), Character 11; Wang & Zhu (2018), Character 48. 


### PR DESCRIPTION
In Sinolepids, the anterior and posterior plates on the trunk shield are missing, so the lateral walls of the trunk shield is more flat, if there is one of the anterior and posterior plates on the trunk shield, the lateral wall of the trunk shield will be relatively higher.