### PR TITLE
Update Character96、97 list of antiarchs to be compiled.md

### DIFF
--- a/Character list of antiarchs to be compiled.md
+++ b/Character list of antiarchs to be compiled.md
@@ -451,3 +451,12 @@
 > Retchie et al. (1992), Character 11.
 
 > - Retchie et al. (1992) regarded it is a synapomorphy of sinolepids and euantiarchs.
+
+96. Overlying area of posterolateral margin of anterior median dorsal plate: narrow (0); wide (1).
+
+  >**Newly added character.**
+
+97. Index r3 between anterior and posterior divisions of posterior median dorsal plate (ordered): r3<300 (0); r3>300 (1).
+
+  >**Newly added character.**
+> - In _"Xichonoiepis"_, the ratio of the lateral process to the posterior margin divisions and lateral process to anterior margin divisions is less than 300 in the posterior median dorsal plate of the Zhujiangyuan,  and the ratio of the lateral process to the posterior margin divisions and lateral process to anterior margin divisions is greater than 300 in the posterior median dorsal plate of the Wuding.


### PR DESCRIPTION
Character96 In _"xichonoiepis"_ from the Zhujiangyuan, the Overlying area of posterolateral margin of anterior median dorsal plate is very narrow.

Character97 In _"Xichonoiepis"_, the ratio of the lateral process to the posterior margin divisions and lateral process to anterior margin divisions is less than 300 in the posterior median dorsal plate of the Zhujiangyuan,  and the ratio of the lateral process to the posterior margin divisions and lateral process to anterior margin divisions is greater than 300 in the posterior median dorsal plate of the Wuding.

