### PR TITLE
Update Character 96

### DIFF
--- a/Character list of antiarchs to be compiled.md
+++ b/Character list of antiarchs to be compiled.md
@@ -250,7 +250,7 @@
 
 > - **very low trunk shield in *Xichonolepis* should be a derived feature. Is this a feature of sinolepids? How to define it?**
 
-51. Anterior and posterior lateral of trunk shield: all absent (0); one of present or all of present (1).
+51. Anterior and posterior lateral plate of trunk shield: all absent (0); one of present or all of present (1).
 
 > **Newly added character (Yan).**
 
@@ -469,6 +469,7 @@
 > **Newly added character.**
 
 > - Do you mean the contact face? How to define narrow or wide?
+> - The overlying area of posterolateral margin of anterior median dorsal plate refers to the contact face where the anterior median dorsal plate overlap the posterior dorsolateral plate. In the _Xichonolepis_ collected in Wuding, the maximum width of the posterolateral overlying area of the anterior median dorsal plate is 5 cm, which gradually decreases from the posteriolateral corner towards the lateral corner. In the _Xichonolepis_ collected in the Pearl River source, the maximum width of the posterolateral overlying area of the anterior median dorsal plate is 2 cm, which gradually decreases from the posteriolateral corner towards the lateral corner, and disappearing at approximately 3/4 of the length of the posterolateral margin.
 
 97. Index r3 between anterior and posterior divisions of posterior median dorsal plate: r3<300 (0); r3>=300 (1).
 


### PR DESCRIPTION
Do you mean the contact face? How to define narrow or wide?
The overlying area of posterolateral margin of anterior median dorsal plate refers to the contact face where the anterior median dorsal plate overlap the posterior dorsolateral plate. In the Xichonolepis collected in Wuding, the maximum width of the posterolateral overlying area of the anterior median dorsal plate is 5 mm, which gradually decreases from the posteriolateral corner towards the lateral corner. In the Xichonolepis collected in the Pearl River source, the maximum width of the posterolateral overlying area of the anterior median dorsal plate is 2 mm, which gradually decreases from the posteriolateral corner towards the lateral corner, and disappearing at approximately 3/4 of the length of the posterolateral margin.